### PR TITLE
Update CSRF_TRUSTED_ORIGINS in settings.py to include 'http://localho…

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -170,6 +170,6 @@ REST_FRAMEWORK = {
  
 
 CSRF_TRUSTED_ORIGINS = [
-    'localhost:8000',
+    'http://localhost:8000',
     'https://projac-backend-nsrbuokksa-rj.a.run.app'
 ]


### PR DESCRIPTION
…st:8000' for cross-origin requests.