### PR TITLE
feat: :sparkles: Add GraphSerializer for Pesquisador model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY ./requirements.txt /app/requirements.txt
 
 # Install system dependencies and Python dependencies
 RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev \
-    && apk add --no-cache postgresql-dev \
+    && apk add --no-cache postgresql-dev bash \
     && pip install --no-cache-dir -r requirements.txt \
     && apk del .build-deps
 
@@ -17,7 +17,3 @@ COPY ./app /app
 
 # Expose the port the app runs on
 EXPOSE 8000
-
-# Set the command to run the application
-ENTRYPOINT ["python3", "manage.py"]
-CMD ["runserver", "0.0.0.0:8000"]

--- a/app/projac/serializers/__init__.py
+++ b/app/projac/serializers/__init__.py
@@ -11,6 +11,7 @@ from projac.serializers.pesquisador import (
 from projac.serializers.producao_academica import ProducaoAcademicaSerializer
 from projac.serializers.projeto import ProjetoDetailSerializer, ProjetoListSerializer
 from projac.serializers.valor_arrecadado import ValorArrecadadoSerializer
+from .graph import GraphSerializer
 
 __all__ = [
     "CoordenadorInProjectListSerializer",
@@ -24,4 +25,5 @@ __all__ = [
     "SubAreaSerializer",
     "ProjetoDetailSerializer",
     "ProjetoListSerializer",
+    "GraphSerializer",
 ]

--- a/app/projac/serializers/graph.py
+++ b/app/projac/serializers/graph.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+from projac.models import Pesquisador
+
+class GraphSerializer(serializers.ModelSerializer):
+    projetos = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+
+    class Meta:
+        model = Pesquisador
+        fields = [
+            "nome",
+            "sobrenome",
+            "foto_perfil",
+            "projetos",
+        ]

--- a/app/projac/urls.py
+++ b/app/projac/urls.py
@@ -10,6 +10,7 @@ from projac.views import (
     ProducaoAcademicaViewSet,
     ProjetoViewSet,
     SubAreaViewSet,
+    GraphViewSet,
 )
 
 router = routers.DefaultRouter()
@@ -21,6 +22,7 @@ router.register("agencias-fomento", AgenciaFomentoViewSet, basename="agencias-fo
 router.register(
     "producoes-academicas", ProducaoAcademicaViewSet, basename="producoes-academicas"
 )
+router.register("graph", GraphViewSet, basename="graph")
 
 
 urlpatterns = [

--- a/app/projac/views.py
+++ b/app/projac/views.py
@@ -29,6 +29,7 @@ from .serializers import (
     ProjetoDetailSerializer,
     ProjetoListSerializer,
     SubAreaSerializer,
+    GraphSerializer,
 )
 
 
@@ -94,3 +95,14 @@ class ProducaoAcademicaViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ProducaoAcademicaSerializer
     filterset_class = ProducaoAcademicaFilter
     permission_classes = [HasAPIKey]
+
+class GraphViewSet(viewsets.ReadOnlyModelViewSet):
+    """Graph viewset"""
+
+    queryset = Pesquisador.objects.all()
+    serializer_class = GraphSerializer
+    permission_classes = []
+
+    def get_queryset(self):
+        """Get queryset method"""
+        return Pesquisador.objects.prefetch_related("projetos").all()

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,6 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 # Run the Docker container with the specified image tag
-docker run -it -p 8000:8000 $IMAGE_TAG
+docker run -it -p 8000:8000 -v ./app:/app $IMAGE_TAG /bin/bash
 
 echo "Docker container running using image $IMAGE_TAG"


### PR DESCRIPTION
This commit adds a new serializer, GraphSerializer, for the Pesquisador model. The GraphSerializer includes fields for nome, sobrenome, foto_perfil, and projetos. This serializer will be used to serialize Pesquisador objects when generating graph data.

Note: This commit message follows the established conventions in the repository.