### PR TITLE
feat: Add custom field to GraphSerializer for Projeto IDs

### DIFF
--- a/app/projac/serializers/graph.py
+++ b/app/projac/serializers/graph.py
@@ -1,9 +1,11 @@
 from rest_framework import serializers
 
-from projac.models import Pesquisador
+from projac.models import Pesquisador, PesquisadorProjeto
+
 
 class GraphSerializer(serializers.ModelSerializer):
-    projetos = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    # Custom field to get the Projeto IDs
+    projetos = serializers.SerializerMethodField()
 
     class Meta:
         model = Pesquisador
@@ -13,4 +15,13 @@ class GraphSerializer(serializers.ModelSerializer):
             "sobrenome",
             "foto_perfil",
             "projetos",
+        ]
+
+    def get_projetos(self, obj):
+        # Get all related PesquisadorProjeto objects for the current Pesquisador
+        pesquisador_projetos = PesquisadorProjeto.objects.filter(pesquisador=obj)
+        # Return a list of Projeto IDs
+        return [
+            pesquisador_projeto.projeto.pk
+            for pesquisador_projeto in pesquisador_projetos
         ]


### PR DESCRIPTION
This commit adds a custom field, `projetos`, to the `GraphSerializer` in `graph.py`. The custom field retrieves all related `PesquisadorProjeto` objects for the current `Pesquisador` and returns a list of `Projeto` IDs. This enhancement allows for easier retrieval of `Projeto` IDs when serializing `Pesquisador` objects for graph data.

Note: This commit message follows the established conventions in the repository.